### PR TITLE
Fix: Resolve build failures on macOS and add missing dependency

### DIFF
--- a/rewinddb/core.py
+++ b/rewinddb/core.py
@@ -11,7 +11,7 @@ import time
 import datetime
 import typing
 import logging
-import pysqlcipher3.dbapi2 as sqlite3
+from sqlcipher3 import dbapi2 as sqlite3
 from rewinddb.config import get_db_path, get_db_password
 
 # configure logging

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,11 @@ setuptools.setup(
     ],
     python_requires=">=3.6",
     install_requires=[
-        "pysqlcipher3",
+        "sqlcipher3",
         "pydantic",
         "requests",
         "python-dotenv",
         "mcp>=0.1.0",
+	"tabulate",
     ],
 )


### PR DESCRIPTION
This PR resolves installation and runtime errors on macOS.

Resolves build failures: Replaces the previous SQLCipher package with sqlcipher3 and updates the necessary import in core.py.

Fixes runtime error: Adds the missing tabulate dependency to setup.py.